### PR TITLE
ChatLogger v1.0.0-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ![](https://img.shields.io/github/release/kenygamer/ChatLogger/all.svg)
 ![](https://img.shields.io/github/downloads/kenygamer/ChatLogger/total.svg)
 
-ChatLogger is a PocketMine-MP plugin to log your server chat. It features a /report command to dump a player chat log at a given date.
+ChatLogger is a PocketMine-MP plugin to log your server chat. It features a /export command to dump a player chat log at a given date.
 ## Commands
 | Command | Usage | Description |
 | ------- | ----- | ----------- |
-| `/report` | `/report <player> <date: mm-dd-yy>` | Dumps a player chat log at a given date. |
+| `/export` | `/export <player> <date: mm-dd-yy>` | Dumps a player chat log at a given date. |
 ## Permissions
 ```yml
 chatlogger:
@@ -21,7 +21,7 @@ chatlogger:
    description: Allows access to all ChatLogger commands.
    default: false
    children:
-    chatlogger.command.report:
-     description: Allows access to the ChatLogger report command.
+    chatlogger.command.export:
+     description: Allows access to the ChatLogger export command.
      default: op
 ```

--- a/plugin.yml
+++ b/plugin.yml
@@ -25,5 +25,5 @@ permissions:
     default: false
     children:
      chatlogger.command.export:
-      description: Allows access to the ChatLogger report command.
+      description: Allows access to the ChatLogger export command.
       default: op

--- a/plugin.yml
+++ b/plugin.yml
@@ -7,10 +7,10 @@ author: kenygamer
 description: A PocketMine-MP plugin to log your server chat
 
 commands:
- report:
+ export:
   description: Dumps a player chat log at a given date.
-  usage: "/report <player> <date: mm-dd-yyyy>"
-  permission: chatlogger.command.report
+  usage: "/export <player> <date: mm-dd-yyyy>"
+  permission: chatlogger.command.export
 
 permissions:
  chatlogger:
@@ -24,6 +24,6 @@ permissions:
     description: Allows access to all ChatLogger commands.
     default: false
     children:
-     chatlogger.command.report:
+     chatlogger.command.export:
       description: Allows access to the ChatLogger report command.
       default: op

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -1,7 +1,7 @@
 ---
 
 ## Log player chat message even if PlayerChatLogEvent is cancelled?
-chatlog-force: false
+force: false
 report:
  use-https: true
  host: chatlogger.herokuapp.com

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -1,6 +1,6 @@
 ---
 
-## Only for debugging porpuses. RECOMMENDED IT STAYS FALSE
+## Log player chat message even if PlayerChatLogEvent is cancelled?
 chatlog-force: false
 report:
  use-https: true

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -1,7 +1,11 @@
 ---
 
-## Log player chat message even if PlayerChatLogEvent is cancelled?
+# force: Log player chat message even if PlayerChatLogEvent is cancelled?
 force: false
+
+# provider: Set provider of database (Available: yaml, json)
+provider: yaml
+
 report:
  use-https: true
  host: chatlogger.herokuapp.com

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -1,5 +1,6 @@
 ---
 
+## Only for debugging porpuses. RECOMMENDED IT STAYS FALSE
 chatlog-force: false
 report:
  use-https: true

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -37,6 +37,8 @@ class ChatLogger extends PluginBase implements Listener{
   
   /** @var array */
   private $chatlog;
+  /** @var Provider */
+  private $provider;
   
   public function onEnable() : void{
     $this->getServer()->getPluginManager()->registerEvents($this, $this);

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -121,7 +121,7 @@ class ChatLogger extends PluginBase implements Listener{
       "player" => $player,
       "date" => $date
       ]);
-    $this->getServer()->getScheduler()->scheduleAsyncTask(new ExportTask($this, $sender, $report));
+    $this->getServer()->getScheduler()->scheduleAsyncTask(new ExportTask($sender->getName(), $player, $report));
     return true;
   }
   

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -119,7 +119,8 @@ class ChatLogger extends PluginBase implements Listener{
     
     $report["player"] = $player;
     $report["date"] = $date;
-    $this->getServer()->getScheduler()->scheduleAsyncTask(new ExportTask($sender->getName(), $report));
+    $fqdn = ($this->getConfig()->getNested("report.use-https", true) ? "https" : "http") . "://" . ($this->getConfig()->getNested("report.host", "chatlogger.herokuapp.com"));
+    $this->getServer()->getScheduler()->scheduleAsyncTask(new ExportTask($sender->getName(), $fqdn, $report));
     return true;
   }
   

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -30,6 +30,7 @@ use pocketmine\utils\TextFormat;
 
 use ChatLogger\event\PlayerChatLogEvent;
 use ChatLogger\provider\JsonProvider;
+use ChatLogger\provider\Provider;
 use ChatLogger\provider\YamlProvider;
 use ChatLogger\task\ExportTask;
 
@@ -66,7 +67,9 @@ class ChatLogger extends PluginBase implements Listener{
   }
   
   public function onDisable() : void{
-    $this->provider->close();
+    if($this->provider instanceof Provider){
+      $this->provider->close();
+    }
   }
   
   /**

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -105,7 +105,7 @@ class ChatLogger extends PluginBase implements Listener{
     $report = [];
     foreach($this->provider->getAll() as $pl){
       if($player === $pl){
-        foreach($player as $messages){
+        foreach($pl as $messages){
           foreach($messages as $message){
             if(date("m-d-Y", $message[0]) === $date) $report["messages"] = $message;
           }

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -103,8 +103,14 @@ class ChatLogger extends PluginBase implements Listener{
     $sender->sendMessage("Step 1 of 2: Generating report...");
     
     $report = [];
-    foreach($this->provider->getAll() as $message){
-      if(date("m-d-Y", $message[0]) === $date) $report["messages"] = $message;
+    foreach($this->provider->getAll() as $pl){
+      if($player === $pl){
+        foreach($player as $messages){
+          foreach($messages as $message){
+            if(date("m-d-Y", $message[0]) === $date) $report["messages"] = $message;
+          }
+        }
+      }
     }
     
     if(empty($report)){

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -117,10 +117,8 @@ class ChatLogger extends PluginBase implements Listener{
     $sender->sendMessage("Step 2 of 2: Uploading report...");
     $sender->sendMessage("Report is being uploaded in the background");
     
-    array_push($report, [
-      "player" => $player,
-      "date" => $date
-      ]);
+    $report["player"] = $player;
+    $report["date"] = $date;
     $this->getServer()->getScheduler()->scheduleAsyncTask(new ExportTask($sender->getName(), $player, $report));
     return true;
   }

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -125,7 +125,7 @@ class ChatLogger extends PluginBase implements Listener{
     $message = $event->getMessage();
     
     $this->getServer()->getPluginManager()->callEvent($event = new PlayerChatLogEvent($player, $time, $message));
-    if(!$event->isCancelled() or $this->getConfig()->get("chatlog-force", false) === true){
+    if(!$event->isCancelled() or $this->getConfig()->get("force", false) === true){
       $this->chatlog[strtolower($player->getName())][] = [
         $time,
         $message

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -102,18 +102,12 @@ class ChatLogger extends PluginBase implements Listener{
     
     $sender->sendMessage("Step 1 of 2: Generating report...");
     
-    $report = [];
-    foreach($this->provider->getAll() as $p){
-      if($player === $p){
-        foreach($p as $messages){
-          foreach($messages as $message){
-            if(date("m-d-Y", $message[0]) === $date) $report["messages"][] = $message;
-          }
-        }
-      }
+    $report["messages"] = [];
+    foreach($this->provider->getAll()[$player] as $message){
+      if(date("m-d-Y", $message[0]) === $date) $report["messages"][] = $message;
     }
-    
-    if(!isset($report["messages"])){
+      
+    if(empty($report["messages"])){
       $sender->sendMessage(TextFormat::RED . "Error: Player {$player} has no chat history for this date.");
       return true;
     }

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -103,11 +103,11 @@ class ChatLogger extends PluginBase implements Listener{
     $sender->sendMessage("Step 1 of 2: Generating report...");
     
     $report["messages"] = [];
-    foreach($this->provider->getAll()[$player] as $message){
-      if(date("m-d-Y", $message[0]) === $date){
-        $report["messages"][] = $message;
-      }
-    }
+    foreach($this->provider->getAll()[$player] as $message){ // This
+      if(date("m-d-Y", $message[0]) === $date){ /////////////// code
+        $report["messages"][] = $message; ///////////////////// is
+      } /////////////////////////////////////////////////////// not
+    } ///////////////////////////////////////////////////////// working
       
     if(empty($report["messages"])){
       $sender->sendMessage(TextFormat::RED . "Error: Player {$player} has no chat history for this date.");

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -94,7 +94,11 @@ class ChatLogger extends PluginBase implements Listener{
     $sender->sendMessage("Step 2 of 2: Uploading report...");
     $sender->sendMessage("Report is being uploaded in the background");
     
-    $this->getServer()->getScheduler()->scheduleAsyncTask(new ExportTask($this, $sender, [$player, $date]));
+    array_push($report, [
+      "player" => $player,
+      "date" => $date
+      ]);
+    $this->getServer()->getScheduler()->scheduleAsyncTask(new ExportTask($this, $sender, $report));
     return true;
   }
   

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -126,10 +126,7 @@ class ChatLogger extends PluginBase implements Listener{
     
     $this->getServer()->getPluginManager()->callEvent($event = new PlayerChatLogEvent($player, $time, $message));
     if(!$event->isCancelled() or $this->getConfig()->get("force", false) === true){
-      $this->chatlog[strtolower($player->getName())][] = [
-        $time,
-        $message
-        ];
+      $this->chatlog[strtolower($player->getName())][] = [$time, $message];
       return;
     }
     $this->getLogger()->debug("Failed to log chat message: PlayerChatLogEvent is cancelled");

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -104,7 +104,9 @@ class ChatLogger extends PluginBase implements Listener{
     
     $report["messages"] = [];
     foreach($this->provider->getAll()[$player] as $message){
-      if(date("m-d-Y", $message[0]) === $date) $report["messages"][] = $message;
+      if(date("m-d-Y", $message[0]) === $date){
+        $report["messages"][] = $message;
+      }
     }
       
     if(empty($report["messages"])){

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -119,7 +119,7 @@ class ChatLogger extends PluginBase implements Listener{
     
     $report["player"] = $player;
     $report["date"] = $date;
-    $this->getServer()->getScheduler()->scheduleAsyncTask(new ExportTask($sender->getName(), $player, $report));
+    $this->getServer()->getScheduler()->scheduleAsyncTask(new ExportTask($sender->getName(), $report));
     return true;
   }
   

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -100,7 +100,7 @@ class ChatLogger extends PluginBase implements Listener{
       return true;
     }
     
-    $sender->sendMessage("Step 1 of 2: Generating report...");
+    $sender->sendMessage("Step " . TextFormat::GREEN . "1" . TextFormat::WHITE . " of " . TextFormat::GREEN . "2" . TextFormat::WHITE . ": Generating report...");
     
     $report["messages"] = [];
     foreach($this->provider->getMessages($player) as $message){
@@ -114,7 +114,7 @@ class ChatLogger extends PluginBase implements Listener{
       return true;
     }
     
-    $sender->sendMessage("Step 2 of 2: Uploading report...");
+    $sender->sendMessage("Step " . TextFormat::GREEN . "2" . TextFormat::WHITE . " of " . TextFormat::GREEN . "2" . TextFormat::WHITE . ": Uploading report...");
     $sender->sendMessage("Report is being uploaded in the background");
     
     $report["player"] = $player;

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -138,7 +138,7 @@ class ChatLogger extends PluginBase implements Listener{
     
     $this->getServer()->getPluginManager()->callEvent($event = new PlayerChatLogEvent($player, $time, $message));
     if(!$event->isCancelled() or $this->getConfig()->get("force", false) === true){
-      $this->provider->logMessage(strtolower($player->getName()), $time, $message);
+      $this->provider->logMessage($player, $time, $message);
       return;
     }
     $this->getLogger()->debug("Failed to log chat message: PlayerChatLogEvent is cancelled");

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -103,17 +103,17 @@ class ChatLogger extends PluginBase implements Listener{
     $sender->sendMessage("Step 1 of 2: Generating report...");
     
     $report = [];
-    foreach($this->provider->getAll() as $pl){
-      if($player === $pl){
-        foreach($pl as $messages){
+    foreach($this->provider->getAll() as $p){
+      if($player === $p){
+        foreach($p as $messages){
           foreach($messages as $message){
-            if(date("m-d-Y", $message[0]) === $date) $report["messages"] = $message;
+            if(date("m-d-Y", $message[0]) === $date) $report["messages"][] = $message;
           }
         }
       }
     }
     
-    if(empty($report)){
+    if(!isset($report["messages"])){
       $sender->sendMessage(TextFormat::RED . "Error: Player {$player} has no chat history for this date.");
       return true;
     }

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -85,7 +85,7 @@ class ChatLogger extends PluginBase implements Listener{
     $player = strtolower($args[0]);
     $date = $args[1];
     
-    if(!isset($this->chatlog[$player])){
+    if(!$this->provider->chattedBefore()){
       $sender->sendMessage(TextFormat::RED . "Error: Player {$player} has no chat history.");
       return true;
     }
@@ -98,8 +98,8 @@ class ChatLogger extends PluginBase implements Listener{
     $sender->sendMessage("Step 1 of 2: Generating report...");
     
     $report = [];
-    foreach($this->chatlog[$player] as $message){
-      if(date("m-d-Y", $message[0]) === $date) $report[] = $message;
+    foreach($this->provider->getAll() as $message){
+      if(date("m-d-Y", $message[0]) === $date) $report["messages"] = $message;
     }
     
     if(empty($report)){

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -103,11 +103,11 @@ class ChatLogger extends PluginBase implements Listener{
     $sender->sendMessage("Step 1 of 2: Generating report...");
     
     $report["messages"] = [];
-    foreach($this->provider->getAll()[$player] as $message){ // This
-      if(date("m-d-Y", $message[0]) === $date){ /////////////// code
-        $report["messages"][] = $message; ///////////////////// is
-      } /////////////////////////////////////////////////////// not
-    } ///////////////////////////////////////////////////////// working
+    foreach($this->provider->getMessages($player) as $message){
+      if(date("m-d-Y", $message[0]) === $date){
+        $report["messages"][] = $message;
+      }
+    }
       
     if(empty($report["messages"])){
       $sender->sendMessage(TextFormat::RED . "Error: Player {$player} has no chat history for this date.");

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -85,7 +85,7 @@ class ChatLogger extends PluginBase implements Listener{
     $player = strtolower($args[0]);
     $date = $args[1];
     
-    if(!$this->provider->chattedBefore()){
+    if(!$this->provider->chattedBefore($player)){
       $sender->sendMessage(TextFormat::RED . "Error: Player {$player} has no chat history.");
       return true;
     }

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -47,11 +47,11 @@ class ChatLogger extends PluginBase implements Listener{
     
     $provider = strtolower($this->getConfig()->get("provider", "yaml"));
     switch($provider){
-      case "yaml":
-        $this->provider = new YamlProvider($this);
-        break;
       case "json":
         $this->provider = new JsonProvider($this);
+        break;
+      case "yaml":
+        $this->provider = new YamlProvider($this);
         break;
       default:
         $this->getLogger()->warning("Invalid database provider " . $provider . ", resetting to `yaml`");

--- a/src/ChatLogger/ChatLogger.php
+++ b/src/ChatLogger/ChatLogger.php
@@ -138,7 +138,7 @@ class ChatLogger extends PluginBase implements Listener{
     
     $this->getServer()->getPluginManager()->callEvent($event = new PlayerChatLogEvent($player, $time, $message));
     if(!$event->isCancelled() or $this->getConfig()->get("force", false) === true){
-      $this->chatlog[strtolower($player->getName())][] = [$time, $message];
+      $this->provider->logMessage(strtolower($player->getName()), $time, $message);
       return;
     }
     $this->getLogger()->debug("Failed to log chat message: PlayerChatLogEvent is cancelled");

--- a/src/ChatLogger/provider/JsonProvider.php
+++ b/src/ChatLogger/provider/JsonProvider.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * ChatLogger - A PocketMine-MP plugin to log your server chat
+ * Copyright (C) 2017 Kevin Andrews <https://github.com/kenygamer/ChatLogger>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+*/
+
+declare(strict_types=1);
+
+namespace ChatLogger\provider;
+
+use pocketmine\Player;
+use pocketmine\utils\Config;
+
+use ChatLogger\ChatLogger;
+
+class JsonProvider implements Provider{
+  
+  /** @var ChatLogger */
+  private $plugin;
+  /** @var array|null */
+  private $chatlog = null;
+  
+  public function __construct(ChatLogger $plugin){
+    $this->plugin = $plugin;
+  }
+  
+  public function open() : bool{
+    if($this->chatlog !== null){
+      return false;
+    }
+    $this->chatlog = (new Config($this->plugin->getDataFolder() . "chatlog.json", Config::JSON))->getAll();
+    return true;
+  }
+  
+  public function getName() : string{
+    return "Json";
+  }
+  
+  public function chattedBefore(string $player) : bool{
+    return isset($this->chatlog[strtolower($player)]);
+  }
+  
+  public function logMessage(Player $player, int $time, string $message) : void{
+    $this->chatlog[strtolower($player->getName())][] = [$time, $message];
+  }
+  
+  public function getAll() : array{
+    return $this->chatlog;
+  }
+  
+  public function close() : void{
+    $chatlog = new Config($this->plugin->getDataFolder() . "chatlog.json", Config::JSON);
+    $chatlog->setAll($this->chatlog);
+    $chatlog->save();
+  }
+  
+}

--- a/src/ChatLogger/provider/JsonProvider.php
+++ b/src/ChatLogger/provider/JsonProvider.php
@@ -55,8 +55,8 @@ class JsonProvider implements Provider{
     $this->chatlog[strtolower($player->getName())][] = [$time, $message];
   }
   
-  public function getAll() : array{
-    return $this->chatlog;
+  public function getMessages(string $player) : array{
+    return $this->chatlog[strtolower($player)];
   }
   
   public function close() : void{

--- a/src/ChatLogger/provider/Provider.php
+++ b/src/ChatLogger/provider/Provider.php
@@ -1,3 +1,5 @@
+<?php
+
 /*
  * ChatLogger - A PocketMine-MP plugin to log your server chat
  * Copyright (C) 2017 Kevin Andrews <https://github.com/kenygamer/ChatLogger>
@@ -17,4 +19,28 @@ declare(strict_types=1);
 
 namespace ChatLogger\provider;
 
+use ChatLogger\ChatLogger;
+
 interface Provider{
+  
+  /**
+   * @param ChatLogger $plugin
+   */
+  public function __construct(ChatLogger $plugin){
+  }
+  
+  /**
+   * @param string $player
+   *
+   * @return bool
+   */
+  public function chattedBefore(string $player) : bool;
+  
+  /**
+   * @return array
+   */
+  public function getAll() : array;
+  
+  public function close() : void;
+  
+  private function save() : void;

--- a/src/ChatLogger/provider/Provider.php
+++ b/src/ChatLogger/provider/Provider.php
@@ -49,19 +49,16 @@ interface Provider{
   
   /**
    * @param Player $player
-   *
-   * @return void
    */
   public function logMessage(Player $player, int $time, string $message) : void;
   
   /**
+   * @param string $player
+   *
    * @return array
    */
-  public function getAll() : array;
+  public function getMessages(string $player) : array;
   
-  /**
-   * @return void
-   */
   public function close() : void;
   
 }

--- a/src/ChatLogger/provider/Provider.php
+++ b/src/ChatLogger/provider/Provider.php
@@ -32,11 +32,14 @@ interface Provider{
   }
   
   /**
+   * @return bool
+   */
+  public function open() : bool;
+  
+  /**
    * @return string
    */
-  public function getName() : string{
-    return "Yaml";
-  }
+  public function getName() : string;
   
   /**
    * @param Player $player

--- a/src/ChatLogger/provider/Provider.php
+++ b/src/ChatLogger/provider/Provider.php
@@ -52,7 +52,7 @@ interface Provider{
    *
    * @return void
    */
-  public function logMessage(Player $player) : void;
+  public function logMessage(Player $player, int $time, string $message) : void;
   
   /**
    * @return array

--- a/src/ChatLogger/provider/Provider.php
+++ b/src/ChatLogger/provider/Provider.php
@@ -28,8 +28,7 @@ interface Provider{
   /**
    * @param ChatLogger $plugin
    */
-  public function __construct(ChatLogger $plugin){
-  }
+  public function __construct(ChatLogger $plugin);
   
   /**
    * @return bool

--- a/src/ChatLogger/provider/Provider.php
+++ b/src/ChatLogger/provider/Provider.php
@@ -19,6 +19,8 @@ declare(strict_types=1);
 
 namespace ChatLogger\provider;
 
+use pocketmine\Player;
+
 use ChatLogger\ChatLogger;
 
 interface Provider{
@@ -30,17 +32,25 @@ interface Provider{
   }
   
   /**
-   * @param string $player
+   * @return string
+   */
+  public function getName() : string{
+    return "Yaml";
+  }
+  
+  /**
+   * @param Player $player
    *
    * @return bool
    */
-  public function chattedBefore(string $player) : bool;
+  public function chattedBefore(Player $player) : bool;
   
   /**
    * @return array
    */
   public function getAll() : array;
   
+  /**
+   * @return void
+   */
   public function close() : void;
-  
-  private function save() : void;

--- a/src/ChatLogger/provider/Provider.php
+++ b/src/ChatLogger/provider/Provider.php
@@ -1,0 +1,20 @@
+/*
+ * ChatLogger - A PocketMine-MP plugin to log your server chat
+ * Copyright (C) 2017 Kevin Andrews <https://github.com/kenygamer/ChatLogger>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+*/
+
+declare(strict_types=1);
+
+namespace ChatLogger\provider;
+
+interface Provider{

--- a/src/ChatLogger/provider/Provider.php
+++ b/src/ChatLogger/provider/Provider.php
@@ -42,11 +42,18 @@ interface Provider{
   public function getName() : string;
   
   /**
-   * @param Player $player
+   * @param string $player
    *
    * @return bool
    */
-  public function chattedBefore(Player $player) : bool;
+  public function chattedBefore(string $player) : bool;
+  
+  /**
+   * @param Player $player
+   *
+   * @return void
+   */
+  public function logMessage(Player $player) : void;
   
   /**
    * @return array

--- a/src/ChatLogger/provider/Provider.php
+++ b/src/ChatLogger/provider/Provider.php
@@ -63,3 +63,5 @@ interface Provider{
    * @return void
    */
   public function close() : void;
+  
+}

--- a/src/ChatLogger/provider/YamlProvider.php
+++ b/src/ChatLogger/provider/YamlProvider.php
@@ -64,3 +64,5 @@ class YamlProvider implements Provider{
     $chatlog->setAll($this->chatlog);
     $chatlog->save();
   }
+  
+}

--- a/src/ChatLogger/provider/YamlProvider.php
+++ b/src/ChatLogger/provider/YamlProvider.php
@@ -22,3 +22,21 @@ namespace ChatLogger\provider;
 use pocketmine\Player;
 
 use ChatLogger\ChatLogger;
+
+class YamlProvider implements Provider{
+  
+  /** @var ChatLogger */
+  private $plugin;
+  /** @var array|null */
+  private $chatlog = null;
+  
+  public function __construct(ChatLogger $plugin){
+    $this->plugin = $plugin;
+  }
+  
+  public function open() : bool{
+    if($this->chatlog !== null){
+      return false;
+    }
+    $this->chatlog = (new Config($this->plugin->getDataFolder() . "chatlog.yml", Config::YAML))->getAll();
+  }

--- a/src/ChatLogger/provider/YamlProvider.php
+++ b/src/ChatLogger/provider/YamlProvider.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace ChatLogger\provider;
 
 use pocketmine\Player;
+use pocketmine\utils\Config;
 
 use ChatLogger\ChatLogger;
 
@@ -39,4 +40,17 @@ class YamlProvider implements Provider{
       return false;
     }
     $this->chatlog = (new Config($this->plugin->getDataFolder() . "chatlog.yml", Config::YAML))->getAll();
+    return true;
+  }
+  
+  public function getName() : string{
+    return "Yaml";
+  }
+  
+  public function chattedBefore(string $player) : bool{
+    return isset($this->chatlog[strtolower($player)]);
+  }
+  
+  public function logMessage(Player $player, int $time, string $message) : void{
+    $this->chatlog[strtolower($player->getName())][] = [$time, $message];
   }

--- a/src/ChatLogger/provider/YamlProvider.php
+++ b/src/ChatLogger/provider/YamlProvider.php
@@ -54,3 +54,13 @@ class YamlProvider implements Provider{
   public function logMessage(Player $player, int $time, string $message) : void{
     $this->chatlog[strtolower($player->getName())][] = [$time, $message];
   }
+  
+  public function getAll() : array{
+    return $this->chatlog;
+  }
+  
+  public function close() : void{
+    $chatlog = new Config($this->plugin->getDataFolder() . "chatlog.yml", Config::YAML);
+    $chatlog->setAll($this->chatlog);
+    $chatlog->save();
+  }

--- a/src/ChatLogger/provider/YamlProvider.php
+++ b/src/ChatLogger/provider/YamlProvider.php
@@ -55,8 +55,8 @@ class YamlProvider implements Provider{
     $this->chatlog[strtolower($player->getName())][] = [$time, $message];
   }
   
-  public function getAll() : array{
-    return $this->chatlog;
+  public function getMessages(string $player) : array{
+    return $this->chatlog[$player];
   }
   
   public function close() : void{

--- a/src/ChatLogger/provider/YamlProvider.php
+++ b/src/ChatLogger/provider/YamlProvider.php
@@ -56,7 +56,7 @@ class YamlProvider implements Provider{
   }
   
   public function getMessages(string $player) : array{
-    return $this->chatlog[$player];
+    return $this->chatlog[strtolower($player)];
   }
   
   public function close() : void{

--- a/src/ChatLogger/provider/YamlProvider.php
+++ b/src/ChatLogger/provider/YamlProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * ChatLogger - A PocketMine-MP plugin to log your server chat
+ * Copyright (C) 2017 Kevin Andrews <https://github.com/kenygamer/ChatLogger>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+*/
+
+declare(strict_types=1);
+
+namespace ChatLogger\provider;
+
+use pocketmine\Player;
+
+use ChatLogger\ChatLogger;

--- a/src/ChatLogger/task/ExportTask.php
+++ b/src/ChatLogger/task/ExportTask.php
@@ -48,7 +48,7 @@ class ExportTask extends AsyncTask{
     $this->reply = Utils::postURL($this->fqdn, [
       "player" => $this->report["player"],
       "date" => $this->report["date"],
-      "messages" => $this->report["messages"]]);
+      "messages" => json_encode($this->report["messages"])]);
   }
   
   /**
@@ -60,7 +60,7 @@ class ExportTask extends AsyncTask{
         $sender->sendMessage("Report for " . TextFormat::GREEN . $this->report["player"] . TextFormat::WHITE . " successfully uploaded.");
         $sender->sendMessage("URL: " . TextFormat::GREEN . $this->reply);
       }else{
-        $sender->sendMessage(TextFormat::RED . "Error: host {$this->fqdn} timed out.");
+        $sender->sendMessage(TextFormat::RED . "Error: host " . str_replace(["http://", "https://"], "", $this->fqdn) . " timed out.");
       }
     }
   }

--- a/src/ChatLogger/task/ExportTask.php
+++ b/src/ChatLogger/task/ExportTask.php
@@ -38,8 +38,9 @@ class ExportTask extends AsyncTask{
    * @param string $sender
    * @param array $report
    */
-  public function __construct(string $sender, array $report){
+  public function __construct(string $sender, string $fqdn, array $report){
     $this->sender = $sender;
+    $this->fqdn = $fqdn;
     $this->report = $report;
   }
   

--- a/src/ChatLogger/task/ExportTask.php
+++ b/src/ChatLogger/task/ExportTask.php
@@ -14,3 +14,50 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
 */
+
+use pocketmine\command\CommandSender;
+use pocketmine\scheduler\AsyncTask;
+use pocketmine\Server;
+
+use ChatLogger\ChatLogger;
+
+class ExportTask extends AsyncTask{
+  
+  /** @var ChatLogger */
+  private $plugin;
+  /** @var CommandSender */
+  private $sender;
+  /** @var array */
+  private $report;
+  /** @var string|bool */
+  private $reply = false;
+  
+  /**
+   * @param ChatLogger $plugin
+   * @param CommandSender $sender
+   * @param array $report
+   */
+  public function __construct(ChatLogger $plugin, CommandSender $sender, array $report){
+    $this->plugin = $plugin;
+    $this->sender = $sender;
+    $this->report = $report;
+  }
+  
+  public function onRun(){
+    $url = ($this->plugin->getConfig()->getNested("report.use-https", true) ? "https" : "http") . "://" . $this->plugin->getConfig()->getNested("report.host", "chatlogger.herokuapp.com") . "/api/";
+    $this->reply = Utils::postURL($url, $this->report);
+  }
+  
+  /**
+   * @param Server $server
+   */
+  public function onCompletion(Server $server){
+    if($this->reply !== false and filter_var($this->reply, FILTER_VALIDATE_URL)){
+      $this->sender->sendMessage("Report for " . TextFormat::GREEN . $this->report["player"] . TextFormat::WHITE . " successfully uploaded.");
+      $this->sender->sendMessage("URL: " . TextFormat::GREEN . $this->reply);
+    }else{
+      $this->sender->sendMessage(TextFormat::RED . "Error: host " . $this->plugin->getConfig()->getNested("report.host", "chatlogger.herokuapp.com") . " timed out.");
+    }
+  }
+  
+}

--- a/src/ChatLogger/task/ExportTask.php
+++ b/src/ChatLogger/task/ExportTask.php
@@ -48,7 +48,7 @@ class ExportTask extends AsyncTask{
     $this->reply = Utils::postURL($this->fqdn, [
       "player" => $this->report["player"],
       "date" => $this->report["date"],
-      "messages" => $this->report["messages"]);
+      "messages" => $this->report["messages"]]);
   }
   
   /**

--- a/src/ChatLogger/task/ExportTask.php
+++ b/src/ChatLogger/task/ExportTask.php
@@ -46,9 +46,9 @@ class ExportTask extends AsyncTask{
   
   public function onRun(){
     $this->reply = Utils::postURL($this->fqdn, [
-      "player" => $report["player"],
-      "date" => $report["date"],
-      "messages" => $report["messages"]);
+      "player" => $this->report["player"],
+      "date" => $this->report["date"],
+      "messages" => $this->report["messages"]);
   }
   
   /**

--- a/src/ChatLogger/task/ExportTask.php
+++ b/src/ChatLogger/task/ExportTask.php
@@ -45,7 +45,10 @@ class ExportTask extends AsyncTask{
   }
   
   public function onRun(){
-    $this->reply = Utils::postURL($this->fqdn, $this->report);
+    $this->reply = Utils::postURL($this->fqdn, [
+      "player" => $report["player"],
+      "date" => $report["date"],
+      "messages" => $report["messages"]));
   }
   
   /**

--- a/src/ChatLogger/task/ExportTask.php
+++ b/src/ChatLogger/task/ExportTask.php
@@ -61,3 +61,5 @@ class ExportTask extends AsyncTask{
       }
     }
   }
+  
+}

--- a/src/ChatLogger/task/ExportTask.php
+++ b/src/ChatLogger/task/ExportTask.php
@@ -48,7 +48,7 @@ class ExportTask extends AsyncTask{
     $this->reply = Utils::postURL($this->fqdn, [
       "player" => $report["player"],
       "date" => $report["date"],
-      "messages" => $report["messages"]));
+      "messages" => $report["messages"]);
   }
   
   /**

--- a/src/ChatLogger/task/ExportTask.php
+++ b/src/ChatLogger/task/ExportTask.php
@@ -48,7 +48,7 @@ class ExportTask extends AsyncTask{
     $this->reply = Utils::postURL($this->fqdn, [
       "player" => $this->report["player"],
       "date" => $this->report["date"],
-      "messages" => json_encode($this->report["messages"])]);
+      "messages" => json_encode((array)$this->report["messages"])]);
   }
   
   /**

--- a/src/ChatLogger/task/ExportTask.php
+++ b/src/ChatLogger/task/ExportTask.php
@@ -15,6 +15,8 @@
  * GNU General Public License for more details.
 */
 
+namespace ChatLogger\task;
+
 use pocketmine\command\CommandSender;
 use pocketmine\scheduler\AsyncTask;
 use pocketmine\Server;

--- a/src/ChatLogger/task/ExportTask.php
+++ b/src/ChatLogger/task/ExportTask.php
@@ -46,7 +46,7 @@ class ExportTask extends AsyncTask{
   }
   
   public function onRun(){
-    $url = ($this->plugin->getConfig()->getNested("report.use-https", true) ? "https" : "http") . "://" . $this->plugin->getConfig()->getNested("report.host", "chatlogger.herokuapp.com") . "/api/";
+    $url = ($this->plugin->getConfig()->getNested("report.use-https", true) ? "https" : "http") . "://" . $this->plugin->getConfig()->getNested("report.host", "chatlogger.herokuapp.com");
     $this->reply = Utils::postURL($url, $this->report);
   }
   

--- a/src/ChatLogger/task/ExportTask.php
+++ b/src/ChatLogger/task/ExportTask.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * ChatLogger - A PocketMine-MP plugin to log your server chat
+ * Copyright (C) 2017 Kevin Andrews <https://github.com/kenygamer/ChatLogger>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+*/


### PR DESCRIPTION
- Rename /report to /export.
- Allow the user to choose between data providers.
- Allow the user to specify the `?format` parameter in the API website to accept `text` and `json` export formats.
- Implement asynchronous tasks when generating reports.

API for ChatLogger v1.0.0-alpha is now **deprecated**. You should upgrade.